### PR TITLE
CDM-128: Add a method to get a spark session

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ WORKDIR /csep
 
 USER spark_user
 
+ENV CSEP_SPARK_JARS_DIR=/opt/bitnami/spark/jars
+
 ENTRYPOINT ["/csep/entrypoint.sh"]

--- a/cdmsparkevents/arg_checkers.py
+++ b/cdmsparkevents/arg_checkers.py
@@ -1,0 +1,81 @@
+'''
+Contains common code for checking method arguments.
+'''
+
+import datetime
+from typing import Any
+import unicodedata
+
+
+def not_falsy(obj: Any, name: str):
+    """
+    Check an argument is not falsy.
+    
+    obj - the argument to check.
+    name - the name of the argument to use in exceptions.
+    
+    returns the object.
+    """
+    if not obj:
+        raise ValueError(f"{name} is required")
+    return obj
+
+
+def require_string(string: str, name: str):
+    """
+    Check an argument is a non-whitespace only string.
+    
+    string - the string to check. Must be either falsy or a string.
+    name - the name of the argument to use in exceptions.
+    
+    returns the stripped string.
+    """
+    if not string or not string.strip():
+        raise ValueError(f"{name} is required")
+    return string.strip()
+
+
+def check_num(num: int | float, name: str, minimum: int | float = 1) -> int | float:
+    """
+    Check an integer or float argument is not None and is greater than some value.
+    
+    num - the number to check. Must None, a float, or an integer.
+    name - the name of the argument to use in exceptions.
+    minimum - the minimum allowed value of the number.
+    
+    returns the number.
+    """
+    if num is None:
+        raise ValueError(f"{name} is required")
+    if num < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    return num
+
+
+def contains_control_characters(string: str, allowed_chars: list[str] = None) -> int:
+    '''
+    Check if a string contains control characters, as denoted by the Unicode character category
+    starting with a C.
+    string - the string to check.
+    allowed_chars - a list of control characters that will be ignored.
+    returns -1 if no characters are control characters not in allowed_chars or the position
+        of the first control character found otherwise.
+    '''
+    # See https://stackoverflow.com/questions/4324790/removing-control-characters-from-a-string-in-python  # noqa: E501
+    allowed_chars = allowed_chars if allowed_chars else []
+    for i, c in enumerate(string):
+        if unicodedata.category(c)[0] == 'C' and c not in allowed_chars:
+                return i
+    return -1
+
+
+def verify_aware_datetime(dt: datetime.datetime, name: str) -> datetime.datetime:
+    """
+    Confirm that a datetime in timezone aware and return the datetime.
+    
+    dt - the datetime to check.
+    name - the name of the argument for error messages.
+    """
+    if not_falsy(dt, name).tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        raise ValueError(f"{name} must be a timezone aware datetime")
+    return dt

--- a/cdmsparkevents/config.py
+++ b/cdmsparkevents/config.py
@@ -69,7 +69,45 @@ class Config(BaseSettings):
         description="A CDM task service token that allows reading all jobs.",
         min_length=1,
     )]
-    
+    minio_url: Annotated[str, Field(
+        validation_alias="CSEP_MINIO_URL",
+        example="https://minio.kbase.us",
+        description="The root URL of the Minio instance for storing data.",
+        min_length=1,
+    )]
+    minio_access_key: Annotated[str, Field(
+        validation_alias="CSEP_MINIO_ACCESS_KEY",
+        example="my_minio_user",
+        description="The Minio access key.",
+        min_length=1,
+    )]
+    minio_secret_key: Annotated[str, Field(
+        validation_alias="CSEP_MINIO_SECRET_KEY",
+        example="supersekrit",
+        description="The Minio secret key.",
+        min_length=1,
+    )]
+    spark_master_url: Annotated[str, Field(
+        validation_alias="CSEP_SPARK_MASTER_URL",
+        example="https://spark.kbase.us",
+        description="The root URL of the Spark cluster master.",
+        min_length=1,
+    )]
+    spark_driver_host: Annotated[str, Field(
+        validation_alias="CSEP_SPARK_DRIVER_HOST",
+        example="event-processor-1.kbase.us",
+        description="The drive host, e.g. the host on which the event processor is running.",
+        min_length=1,
+    )]
+    spark_jars_dir: Annotated[str, Field(
+        validation_alias="CSEP_SPARK_JARS_DIR",
+        example="/opt/bitnami/spark/jars",
+        description="The path to the Spark jars directory. This environment variable is "
+            + "typically provided by the Docker container in which the event processor is "
+            + "running.",
+        min_length=1,
+    )]
+
     _SAFE_FIELDS = {
         "kafka_bootstrap_servers", 
         "kafka_topic_jobs",
@@ -77,6 +115,11 @@ class Config(BaseSettings):
         "kafka_group_id",
         "kafka_max_poll_interval_ms",
         "cdm_task_service_url",
+        "minio_url",
+        "minio_access_key",
+        "spark_master_url",
+        "spark_driver_host",
+        "spark_jars_dir",
     }
     
     def safe_dump(self) -> dict[str, Any]:

--- a/cdmsparkevents/spark.py
+++ b/cdmsparkevents/spark.py
@@ -1,0 +1,83 @@
+"""
+Set up a spark session for use by importers.
+"""
+
+import logging
+from pathlib import Path
+
+from cdmsparkevents.arg_checkers import check_num as _check_num
+from cdmsparkevents.config import Config
+from pyspark.conf import SparkConf
+from pyspark.sql import SparkSession
+
+
+_REQUIRED_JAR_PREFIXES = ["delta-spark_", "hadoop-aws-"]
+
+
+def _find_jars(cfg: Config):
+    logr = logging.getLogger(__name__)
+    directory = Path(cfg.spark_jars_dir).resolve()
+    if not directory.is_dir():
+        raise ValueError(f"Provided spark jars path is not a directory: {directory}")
+    
+    results = []
+
+    for prefix in _REQUIRED_JAR_PREFIXES:
+        matches = list(directory.glob(f"{prefix}*.jar"))
+        if len(matches) != 1:
+            raise ValueError(
+                f"Expected exactly one JAR for prefix '{prefix}', found {len(matches)}"
+            )
+        jar = str(matches[0].resolve())
+        logr.info(f"Found jar {jar}")
+        results.append(jar)
+    
+    return ", ".join(results)
+
+
+def spark_session(cfg: Config, app_name: str, executor_cores: int = 1) -> SparkSession:
+    """
+    Generate a spark session for an importer.
+    
+    cfg - The event processor configuration.
+    app_name - The name for the spark application. This should be unique among applications.
+    executor_cores - the number of cores to use per executor.
+    """
+    # Sourced from https://github.com/kbase/cdm-jupyterhub/blob/main/src/spark/utils.py
+    # with fairly massive changes
+    config = {
+        # Basic config
+        "spark.app.name": app_name,
+        # TODO SPARK will need to provide a partial function to the processor code
+        # so they can choose the number of executor cores while taking advantage of the setup
+        # here
+        # Overrides base image configuration
+        "spark.executor.cores": f"{_check_num(executor_cores, 'executor_cores')}",
+        "spark.driver.host": cfg.spark_driver_host,
+        "spark.master": cfg.spark_master_url,
+        "spark.jars": _find_jars(cfg),
+        
+        # Dynamic allocation is set up in the base image setup.sh script
+
+        # S3 setup
+        "spark.hadoop.fs.s3a.endpoint": cfg.minio_url,
+        "spark.hadoop.fs.s3a.access.key": cfg.minio_access_key,
+        "spark.hadoop.fs.s3a.secret.key": cfg.minio_secret_key,
+        "spark.hadoop.fs.s3a.path.style.access": "true",
+        "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem",
+    
+        # Deltalake setup
+        "spark.sql.extensions": "io.delta.sql.DeltaSparkSessionExtension",
+        "spark.sql.catalog.spark_catalog": "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        "spark.databricks.delta.retentionDurationCheck.enabled": "false",
+        "spark.sql.catalogImplementation": "hive",
+        
+        # Hive config is set up in the base image
+    }
+    
+    spark_conf = SparkConf().setAll(list(config.items()))
+
+    # Initialize SparkSession
+    spark = SparkSession.builder.config(conf=spark_conf).getOrCreate()
+    spark.sparkContext.setLogLevel("ERROR")
+    return spark

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,8 @@ services:
       MINIO_PWD: miniopassword
       MINIO_CTS_USER: cts
       MINIO_CTS_PWD: ctspassword
+      MINIO_EVENTS_USER: events
+      MINIO_EVENTS_PWD: eventspassword
     entrypoint: /s3_policies/minio_create_bucket_entrypoint.sh
     volumes:
       - ./docker_compose/s3_policies:/s3_policies
@@ -95,7 +97,7 @@ services:
       # https://github.com/kbase/auth2/issues/443
       retries: 30
 
-  create_auth2_user:
+  create-auth2-user:
     build:  # yuck. If there's a better way to do this I'm all ears
       context: ./docker_compose/create_auth_user
       dockerfile: Dockerfile
@@ -167,7 +169,7 @@ services:
       POSTGRES_URL: postgres:5432
       DATANUCLEUS_AUTO_CREATE_TABLES: true
 
-  cdm_task_service:
+  cdm-task-service:
     image: ghcr.io/kbase/cdm-task-service:pr-324
     platform: linux/amd64
     ports:
@@ -222,7 +224,8 @@ services:
     volumes:
       - ./docker_compose/cts_helpers:/cts_helpers
 
-  cdm_events:
+  cdm-events:  # do not use underscore or spark will barf
+    user: root
     build:
       context: .
       dockerfile: Dockerfile
@@ -230,9 +233,9 @@ services:
     depends_on:
       postgres:
         condition: service_started
-      cdm_task_service:
+      cdm-task-service:
         condition: service_healthy
-      create_auth2_user:
+      create-auth2-user:
         condition: service_completed_successfully
       kafka:
         condition: service_started
@@ -247,15 +250,25 @@ services:
       CSEP_KAFKA_GROUP_ID: cts_event_processors
       # If a consumer doesn't poll in this interval the broker will treat it as dead
       CSEP_KAFKA_MAX_POLL_INTERVAL_MS: 7200000
-      CSEP_CDM_TASK_SERVICE_URL: http://cdm_task_service:5000
+      CSEP_CDM_TASK_SERVICE_URL: http://cdm-task-service:5000
       # To configure an admin token directly use this env var
       # CSEP_CDM_TASK_SERVICE_ADMIN_TOKEN: token_here
       CSEP_CDM_TASK_SERVICE_ADMIN_TOKEN_FILE:        /shared/token.txt    
-      SPARK_MASTER_URL: spark://spark-master:7077
+      CSEP_MINIO_URL: http://minio:9000
+      CSEP_MINIO_ACCESS_KEY: events
+      CSEP_MINIO_SECRET_KEY: eventspassword
+      CSEP_SPARK_MASTER_URL: spark://spark-master:7077
+      CSEP_SPARK_DRIVER_HOST: cdm-events
+
+      # The following are configuration parameters recognized by the spark base image rather
+      # than the CSEP itself
+      # See https://github.com/kbase/cdm-spark-standalone/blob/main/scripts/setup.sh
+      # for other optional variables
       POSTGRES_USER: hive
       POSTGRES_PASSWORD: hivepassword
       POSTGRES_DB: hive
       POSTGRES_URL: postgres:5432
+      # set to false for production use
       DATANUCLEUS_AUTO_CREATE_TABLES: true
     # TODO SPARK need to config hive template https://github.com/kbase/cdm-spark-standalone/blob/main/scripts/setup.sh#L56-L61
     volumes:

--- a/docker_compose/s3_policies/minio_create_bucket_entrypoint.sh
+++ b/docker_compose/s3_policies/minio_create_bucket_entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+printf "\n*** starting minio bucket & user setup ***\n"
+
 mc alias set minio $MINIO_URL $MINIO_USER $MINIO_PWD
 
 # make cts-logs bucket
@@ -9,10 +11,23 @@ else
   echo 'bucket cts-logs already exists'
 fi
 
+# make test-events bucket
+if ! mc ls minio/test-events 2>/dev/null; then
+  mc mb minio/test-events && echo 'Bucket test-events created'
+else
+  echo 'bucket test-events already exists'
+fi
+
 # create policies
 mc admin policy create minio cdm-task-service-read-write-policy /s3_policies/cdm-task-service-read-write-policy.json
+mc admin policy create minio test-events-read-write-policy /s3_policies/test-events-read-write-policy.json
 
 # make CTS user
 mc admin user add minio $MINIO_CTS_USER $MINIO_CTS_PWD
 mc admin policy attach minio cdm-task-service-read-write-policy --user=$MINIO_CTS_USER
 echo 'CTS user and policy set'
+
+# make events user
+mc admin user add minio $MINIO_EVENTS_USER $MINIO_EVENTS_PWD
+mc admin policy attach minio test-events-read-write-policy --user=$MINIO_EVENTS_USER
+echo 'events user and policy set'

--- a/docker_compose/s3_policies/test-events-read-write-policy.json
+++ b/docker_compose/s3_policies/test-events-read-write-policy.json
@@ -1,0 +1,19 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:GetBucketLocation"
+            ],
+            "Resource": [
+                "arn:aws:s3:::test-events",
+                "arn:aws:s3:::test-events/*"
+            ]
+        }
+    ]
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,4 @@
-#!/bin/sh
-
-# TODO SPARK set up the spark environment. Not sure if everything in /opt/scripts/setup.sh
-# needs to run, but at minimum the hive setup is necessary
-
+#!/bin/bash
 
 # Function to trim whitespace
 trim() {
@@ -35,6 +31,9 @@ else
   export CSEP_CDM_TASK_SERVICE_ADMIN_TOKEN="$token"
   echo "Loaded token from $CSEP_CDM_TASK_SERVICE_ADMIN_TOKEN_FILE into environment."
 fi
+
+# Set up the spark environment
+. /opt/scripts/setup.sh
 
 # exec is needed to replace the shell script as PID 1 so it can recieve sigterm / sigint etc.
 exec python /csep/cdmsparkevents/main.py

--- a/test/arg_checkers_test.py
+++ b/test/arg_checkers_test.py
@@ -1,0 +1,4 @@
+from cdmsparkevents import arg_checkers  # @UnusedImport
+
+def test_noop():
+    pass

--- a/test/spark_test.py
+++ b/test/spark_test.py
@@ -1,0 +1,4 @@
+from cdmsparkevents import spark  # @UnusedImport
+
+def test_noop():
+    pass


### PR DESCRIPTION
```python
$ docker compose exec cdm-events bash
root@d1aff7dea1f1:/csep# pip install ipython
*snip*
root@d1aff7dea1f1:/csep# export CSEP_CDM_TASK_SERVICE_ADMIN_TOKEN=$(cat
/shared/token.txt | tr -d '[:space:]')
root@d1aff7dea1f1:/csep# ipython
Python 3.11.9 (main, Jun 22 2024, 04:32:05) [GCC 12.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.2.0 -- An enhanced Interactive Python. Type '?' for help.
Tip: Use `--theme`, or the `%colors` magic to change IPython's themes
and colors.

In [1]: from cdmsparkevents.config import Config

In [3]: cfg = Config()

In [5]: from cdmsparkevents.spark import spark_session

In [6]: spark = spark_session(cfg, "myspecialapp")
25/05/19 17:42:10 WARN NativeCodeLoader: Unable to load native-hadoop
library for your platform... using builtin-java classes where applicable
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use
setLogLevel(newLevel).
25/05/19 17:42:11 WARN Utils: spark.executor.instances less than
spark.dynamicAllocation.minExecutors is invalid, ignoring its setting,
please update your configs.

In [7]: spark.sql("CREATE DATABASE mytest")
Out[7]: DataFrame[]

In [8]: from pyspark.sql.types import StructType, StructField,
IntegerType, Stri
      ⋮ ngType

In [9]: schema = StructType([
   ...:     StructField("employee_id", IntegerType(), nullable=False),
   ...:     StructField("employee_name", StringType(), nullable=False)
   ...: ])

In [10]: data = [
    ...:     (1, "Alice"),
    ...:     (2, "Bob")
    ...: ]

In [11]: df = spark.createDataFrame(data, schema=schema)

In [12]: df.show()
+-----------+-------------+
|employee_id|employee_name|
+-----------+-------------+
|          1|        Alice|
|          2|          Bob|
+-----------+-------------+

In [13]: df.write.mode("overwrite").option("compression", "snappy").option("path
       ⋮ ", "s3a://test-events/employees.delta").format("delta").saveAsTable("my
       ⋮ test.employees")

In [15]: spark.sql("SELECT * FROM mytest.employees").show()
+-----------+-------------+
|employee_id|employee_name|
+-----------+-------------+
|          1|        Alice|
|          2|          Bob|
+-----------+-------------+
```