### PR TITLE
CDM-128: Optionally run a deltalake connectivity self test at startup

### DIFF
--- a/cdmsparkevents/config.py
+++ b/cdmsparkevents/config.py
@@ -87,6 +87,13 @@ class Config(BaseSettings):
         description="The Minio secret key.",
         min_length=1,
     )]
+    minio_startup_deltalake_self_test_bucket: Annotated[str, Field(
+        validation_alias="CSEP_MINIO_STARTUP_DELTALAKE_SELF_TEST_BUCKET",
+        example="test-bucket",
+        description="A bucket to use for running a self test on startup that checks deltalake "
+            + "read / write ability. If unset the self test is skipped. The test takes seconds "
+            + "to minutes to perform",
+    )]
     spark_master_url: Annotated[str, Field(
         validation_alias="CSEP_SPARK_MASTER_URL",
         example="https://spark.kbase.us",

--- a/cdmsparkevents/main.py
+++ b/cdmsparkevents/main.py
@@ -9,6 +9,7 @@ from pythonjsonlogger.json import JsonFormatter
 
 from cdmsparkevents.config import Config
 from cdmsparkevents.eventloop import EventLoop
+from cdmsparkevents.selftest.startup import run_deltalake_startup_test
 
 
 # httpx is super chatty if the root logger is set to INFO
@@ -52,6 +53,8 @@ def main():
     # Can't use __name__ here since we're expecting to be run as a script, where the name is just
     # __main__
     logging.getLogger("cdmsparkevents.main").info("Service configuration", extra=cfg.safe_dump())
+    if cfg.minio_startup_deltalake_self_test_bucket:
+        run_deltalake_startup_test(cfg)
     evl = EventLoop(cfg)
     try:
         evl.start_event_loop()

--- a/cdmsparkevents/selftest/startup.py
+++ b/cdmsparkevents/selftest/startup.py
@@ -1,0 +1,69 @@
+"""
+Run a basic self test on startup of the event loop. This can take seconds to minutes.
+"""
+
+import logging
+from pyspark.sql.types import StructType, IntegerType, StructField, StringType, Row
+import uuid
+
+from cdmsparkevents.config import Config
+from cdmsparkevents.spark import spark_session
+
+
+def run_deltalake_startup_test(cfg: Config):
+    """
+    Runs a simple check that the service can write to and read from deltalake tables:
+    
+    * Creates a DB with a unique name
+    * Writes a very small amount of data to an employees table
+    * Queries the table
+    * Drops the DB
+    
+    cfg - The event processor configuration.
+    """
+    logr = logging.getLogger(__name__)
+    if not cfg.minio_startup_deltalake_self_test_bucket:
+        raise ValueError("A startup test bucket must be provided in the configuration")
+    name = "cdm_events_startup_test_" + str(uuid.uuid4()).replace("-", "_")
+    schema = StructType([
+       StructField("employee_id", IntegerType(), nullable=False),
+       StructField("employee_name", StringType(), nullable=False)
+    ])
+    data = [
+        (1, "Alice"),
+        (2, "Bob")
+    ]
+    expected_data = [
+        Row(employee_id=1, employee_name="Alice"),
+        Row(employee_id=2, employee_name="Bob")
+    ]
+    spark = spark_session(
+        cfg,
+        name,
+        delta_tables_s3_path=f"{cfg.minio_startup_deltalake_self_test_bucket}/cdm_events_self_test"
+    )
+    df = spark.createDataFrame(data, schema=schema)
+    logr.info(f"Creating self test database {name}")
+    spark.sql(f"CREATE DATABASE {name}")
+    try:
+        logr.info("Writing to self test database")
+        df.write.mode(
+            "overwrite"
+            ).option("compression", "snappy"
+            ).format("delta"
+            ).saveAsTable(f"{name}.employees"
+        )
+        logr.info("Querying self test database")
+        newdf = spark.sql(f"SELECT * FROM {name}.employees")
+        actual_data = newdf.orderBy("employee_id").collect()
+        if expected_data != actual_data:
+            raise ValueError(f"""The startup self test failed. Expected data:
+                {expected_data}
+                Actual data:
+                {actual_data}
+                """
+            )
+    finally:
+        logr.info(f"Dropping self test database {name}")
+        spark.sql(f"DROP DATABASE {name} CASCADE")
+    logr.info("Deltalake connectivity startup self test passed")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,7 @@ services:
       MINIO_PWD: miniopassword
       MINIO_CTS_USER: cts
       MINIO_CTS_PWD: ctspassword
+      MINIO_EVENTS_BUCKET: test-events
       MINIO_EVENTS_USER: events
       MINIO_EVENTS_PWD: eventspassword
     entrypoint: /s3_policies/minio_create_bucket_entrypoint.sh
@@ -257,6 +258,8 @@ services:
       CSEP_MINIO_URL: http://minio:9000
       CSEP_MINIO_ACCESS_KEY: events
       CSEP_MINIO_SECRET_KEY: eventspassword
+      # comment out to skip startup test
+      CSEP_MINIO_STARTUP_DELTALAKE_SELF_TEST_BUCKET: test-events
       CSEP_SPARK_MASTER_URL: spark://spark-master:7077
       CSEP_SPARK_DRIVER_HOST: cdm-events
 

--- a/docker_compose/s3_policies/minio_create_bucket_entrypoint.sh
+++ b/docker_compose/s3_policies/minio_create_bucket_entrypoint.sh
@@ -11,11 +11,11 @@ else
   echo 'bucket cts-logs already exists'
 fi
 
-# make test-events bucket
-if ! mc ls minio/test-events 2>/dev/null; then
-  mc mb minio/test-events && echo 'Bucket test-events created'
+# make events bucket
+if ! mc ls minio/$MINIO_EVENTS_BUCKET 2>/dev/null; then
+  mc mb minio/$MINIO_EVENTS_BUCKET && echo "Bucket $MINIO_EVENTS_BUCKET created"
 else
-  echo 'bucket test-events already exists'
+  echo "bucket $MINIO_EVENTS_BUCKET already exists"
 fi
 
 # create policies


### PR DESCRIPTION
The `spark.sql.warehouse.dir` setting makes Spark SQL manage the deltalake tables, so they're deleted automatically when the database is deleted