### PR TITLE
CDM-128: Always set `spark.sql.warehouse.dir`

### DIFF
--- a/cdmsparkevents/config.py
+++ b/cdmsparkevents/config.py
@@ -87,12 +87,17 @@ class Config(BaseSettings):
         description="The Minio secret key.",
         min_length=1,
     )]
-    minio_startup_deltalake_self_test_bucket: Annotated[str, Field(
-        validation_alias="CSEP_MINIO_STARTUP_DELTALAKE_SELF_TEST_BUCKET",
-        example="test-bucket",
-        description="A bucket to use for running a self test on startup that checks deltalake "
-            + "read / write ability. If unset the self test is skipped. The test takes seconds "
-            + "to minutes to perform",
+    deltalake_s3_warehouse_dir: Annotated[str, Field(
+        validation_alias="CSEP_DELTALAKE_S3_WAREHOUSE_DIR",
+        example="deltalake-bucket/delta_lake_databases",
+        description="An S3 path, starting with the bucket, where deltalake databases will be "
+            + "stored.",
+        min_length=5,
+    )]
+    startup_deltalake_self_test: Annotated[bool, Field(
+        validation_alias="CSEP_STARTUP_DELTALAKE_SELF_TEST",
+        description="Whether to run a self test on startup that checks deltalake "
+            + "read / write ability. The test takes seconds to minutes to perform",
     )]
     spark_master_url: Annotated[str, Field(
         validation_alias="CSEP_SPARK_MASTER_URL",
@@ -124,6 +129,8 @@ class Config(BaseSettings):
         "cdm_task_service_url",
         "minio_url",
         "minio_access_key",
+        "deltalake_s3_warehouse_dir",
+        "startup_deltalake_self_test",
         "spark_master_url",
         "spark_driver_host",
         "spark_jars_dir",

--- a/cdmsparkevents/main.py
+++ b/cdmsparkevents/main.py
@@ -53,7 +53,7 @@ def main():
     # Can't use __name__ here since we're expecting to be run as a script, where the name is just
     # __main__
     logging.getLogger("cdmsparkevents.main").info("Service configuration", extra=cfg.safe_dump())
-    if cfg.minio_startup_deltalake_self_test_bucket:
+    if cfg.startup_deltalake_self_test:
         run_deltalake_startup_test(cfg)
     evl = EventLoop(cfg)
     try:

--- a/cdmsparkevents/selftest/startup.py
+++ b/cdmsparkevents/selftest/startup.py
@@ -22,8 +22,6 @@ def run_deltalake_startup_test(cfg: Config):
     cfg - The event processor configuration.
     """
     logr = logging.getLogger(__name__)
-    if not cfg.minio_startup_deltalake_self_test_bucket:
-        raise ValueError("A startup test bucket must be provided in the configuration")
     name = "cdm_events_startup_test_" + str(uuid.uuid4()).replace("-", "_")
     schema = StructType([
        StructField("employee_id", IntegerType(), nullable=False),
@@ -37,11 +35,7 @@ def run_deltalake_startup_test(cfg: Config):
         Row(employee_id=1, employee_name="Alice"),
         Row(employee_id=2, employee_name="Bob")
     ]
-    spark = spark_session(
-        cfg,
-        name,
-        delta_tables_s3_path=f"{cfg.minio_startup_deltalake_self_test_bucket}/cdm_events_self_test"
-    )
+    spark = spark_session(cfg, name)
     df = spark.createDataFrame(data, schema=schema)
     logr.info(f"Creating self test database {name}")
     spark.sql(f"CREATE DATABASE {name}")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -258,8 +258,8 @@ services:
       CSEP_MINIO_URL: http://minio:9000
       CSEP_MINIO_ACCESS_KEY: events
       CSEP_MINIO_SECRET_KEY: eventspassword
-      # comment out to skip startup test
-      CSEP_MINIO_STARTUP_DELTALAKE_SELF_TEST_BUCKET: test-events
+      CSEP_DELTALAKE_S3_WAREHOUSE_DIR: test-events/delalake_dbs
+      CSEP_STARTUP_DELTALAKE_SELF_TEST: false
       CSEP_SPARK_MASTER_URL: spark://spark-master:7077
       CSEP_SPARK_DRIVER_HOST: cdm-events
 


### PR DESCRIPTION
Users can always specify an S3 path on `df.write`, but then it's on them to clean up after a table / db drop