### PR TITLE
Repoint to KBaseDataLakehouse org

### DIFF
--- a/.github/workflows/build_publish_scan_managed.yaml
+++ b/.github/workflows/build_publish_scan_managed.yaml
@@ -9,7 +9,7 @@ on:
     types: [published]
 jobs:
   build-publish-scan:
-    uses: BERDataLakehouse/.github/.github/workflows/build_publish_scan.yaml@main
+    uses: KBaseDataLakehouse/.github/.github/workflows/build_publish_scan.yaml@main
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /git
 COPY .git /git
 RUN git rev-parse HEAD > /git/git_commit
 
-FROM ghcr.io/berdatalakehouse/kube_spark_manager_image:pr-17
+FROM ghcr.io/kbasedatalakehouse/kube_spark_manager_image:pr-17
 
 USER root
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -188,7 +188,7 @@ services:
       - shared-token:/shared
 
   hive-metastore:
-    image: ghcr.io/berdatalakehouse/hive_metastore:0.0.1
+    image: ghcr.io/kbasedatalakehouse/hive_metastore:0.0.1
     platform: linux/amd64
     ports:
       - "9083:9083"
@@ -214,7 +214,7 @@ services:
       retries: 3
 
   spark-master:
-    image: ghcr.io/berdatalakehouse/kube_spark_manager_image:pr-17
+    image: ghcr.io/kbasedatalakehouse/kube_spark_manager_image:pr-17
     platform: linux/amd64
     ports:
       - 8090:8090
@@ -228,7 +228,7 @@ services:
       MAX_CORES_PER_APPLICATION: 10
 
   spark-worker-1:
-    image: ghcr.io/berdatalakehouse/kube_spark_manager_image:pr-17
+    image: ghcr.io/kbasedatalakehouse/kube_spark_manager_image:pr-17
     platform: linux/amd64
     depends_on:
       - spark-master
@@ -248,7 +248,7 @@ services:
       BERDL_DELTALAKE_WAREHOUSE_DIRECTORY_PATH: fake
 
   spark-worker-2:
-    image: ghcr.io/berdatalakehouse/kube_spark_manager_image:pr-17
+    image: ghcr.io/kbasedatalakehouse/kube_spark_manager_image:pr-17
     platform: linux/amd64
     depends_on:
       - spark-master


### PR DESCRIPTION
Repoint references to the renamed KBaseDataLakehouse org (GHCR namespace / reusable workflow / Codecov slug) after the GitHub org rename.